### PR TITLE
Compile in release mode on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,7 +4,7 @@ mkdir build
 cd build
 
 cmake -G "NMake Makefiles" ^
-      -DCMAKE_BUILD_TYPE=Debug ^
+      -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
       ..

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8e37cd5f3823ec733b1ba6db9a1b4d0b7a0a8fbe7bfb885279befed345fa662a
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
This will avoid errors like the following on Windows: "The code execution cannot proceed because VCRUNTIME140_1D.dll was not found. Reinstalling the program may fix this problem."
Even though it would be convenient to provide a debug version to help us debugging issues in tango-controls, this is not convenient if the user cannot execute UniversalTest out of the box without having to install extra dlls. As explained in https://github.com/conda/conda-verify/issues/67, most users do not have the debug dlls installed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
